### PR TITLE
Improve precision for repeated functions

### DIFF
--- a/Apps/AudioAppTemplate/Source/Repeat.h
+++ b/Apps/AudioAppTemplate/Source/Repeat.h
@@ -8,21 +8,21 @@ namespace AudioApp
     class Repeat
     {
     public:
-        static void repeatFunc(int interval, int count, const std::function<void()>& call) {
+        static void repeatFunc(float interval, int count, const std::function<void()>& call) {
             // TODO: use a single timer here instead?
             // Make first call without overhead of using callAfterDelay.
             call();
             for (int i = 1; i < count; ++i) {
-                juce::Timer::callAfterDelay((i)*interval, call);
+                juce::Timer::callAfterDelay(int((float)i*interval), call);
             }
         }
 
-        static void repeatFunc(int interval, int count, const std::function<void(int index)>& call) {
+        static void repeatFunc(float interval, int count, const std::function<void(int index)>& call) {
             // TODO: use a single timer here instead?
             // Make first call without overhead of using callAfterDelay.
             call(0);
             for (int i = 1; i < count; ++i) {
-                juce::Timer::callAfterDelay((i)*interval, [call, i]{
+                juce::Timer::callAfterDelay(int((float)i*interval), [call, i]{
                     call(i);
                 });
             }

--- a/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.cpp
@@ -29,7 +29,7 @@ namespace AudioApp
             if (onBeat != nullptr) {
                 onBeat(diff);
             }
-            flash( (int)(0.75 * (double)diff));
+            flash( 0.75f * (float)diff);
         }
     }
 
@@ -37,7 +37,7 @@ namespace AudioApp
         btrack.updateHopAndFrameSize(samplePerBlockExpected / 2, samplePerBlockExpected);
     }
 
-    void TempoAnalyserComponent::flash(int duration) {
+    void TempoAnalyserComponent::flash(float duration) {
         Repeat::repeatFunc(duration/fadeIncrements, fadeIncrements, [this](int i){
             this->setColour(juce::Colours::white.interpolatedWith(juce::Colours::grey, (float) i / float(fadeIncrements-1)));
         });

--- a/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.h
+++ b/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.h
@@ -24,7 +24,7 @@ namespace AudioApp
         std::function<void(long long)> onBeat;
 
     private:
-        void flash(int duration);
+        void flash(float duration);
 
         // these need to be set above where we initialise btrack
         int btrackFrameSize = 512;

--- a/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.cpp
@@ -31,15 +31,15 @@ namespace AudioApp
         diffEwma = ewma(diffEwma, (double)period, 0.5);
 
         const int multiplier = 16;
-        Repeat::repeatFunc((int)((double)diffEwma/(double)multiplier), multiplier, [this]{
+        Repeat::repeatFunc(((float)diffEwma/(float)multiplier), multiplier, [this]{
             currentBeat = ++currentBeat%4;
             this->updateLabel(currentBeat);
         });
 
-        flash((int)(0.75 * (double)diffEwma));
+        flash(0.75f * (float)diffEwma);
     }
 
-    void TempoSynthesizerComponent::flash(int duration) {
+    void TempoSynthesizerComponent::flash(float duration) {
         Repeat::repeatFunc(duration/fadeIncrements, fadeIncrements, [this](int i){
             this->updateLabelColour(juce::Colours::white.interpolatedWith(juce::Colours::grey, (float) i / float(fadeIncrements-1)));
         });

--- a/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
+++ b/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
@@ -28,7 +28,7 @@ namespace AudioApp
         std::string content;
         std::atomic<bool> dirty;
 
-        void flash(int duration);
+        void flash(float duration);
         void updateLabel(uint8_t beat);
         void updateLabelColour(juce::Colour newColour);
 


### PR DESCRIPTION
Before this we were accepting a repeat interval as an int.
When multiplfying this to calculate delay times the rounding
error would become multiplied.