### PR TITLE
⚡️ increase accuracy of synthesized beat scheduling

### DIFF
--- a/Apps/AudioAppTemplate/Source/LogOutputComponent.h
+++ b/Apps/AudioAppTemplate/Source/LogOutputComponent.h
@@ -11,8 +11,7 @@ namespace AudioApp
         std::string message;
     };
 
-    class LogOutputComponent : public juce::Component, juce::Timer, public Logger
-    {
+    class LogOutputComponent : public juce::Component, juce::Timer, public Logger {
     public:
         LogOutputComponent();
 

--- a/Apps/AudioAppTemplate/Source/MainComponent.h
+++ b/Apps/AudioAppTemplate/Source/MainComponent.h
@@ -27,7 +27,7 @@ private:
     LogOutputComponent logger;
     AudioSourceComponent audioSource { deviceManager, logger };
     TempoAnalyserComponent tempoAnalyser;
-    TempoSynthesizerComponent tempoSynthesizer;
+    TempoSynthesizerComponent tempoSynthesizer { logger };
     OSCComponent oscComponent { logger };
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
 };

--- a/Apps/AudioAppTemplate/Source/MainComponent.h
+++ b/Apps/AudioAppTemplate/Source/MainComponent.h
@@ -27,7 +27,7 @@ private:
     LogOutputComponent logger;
     AudioSourceComponent audioSource { deviceManager, logger };
     TempoAnalyserComponent tempoAnalyser;
-    TempoSynthesizerComponent tempoSynthesizer { logger };
+    TempoSynthesizerComponent tempoSynthesizer;
     OSCComponent oscComponent { logger };
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
 };

--- a/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.cpp
@@ -5,7 +5,7 @@ namespace AudioApp
     static const int fadeIncrements = 16;
 
     TempoAnalyserComponent::TempoAnalyserComponent() {
-        startTimerHz(30);
+        startTimerHz(60);
     }
 
     void TempoAnalyserComponent::paint(Graphics& g) {
@@ -29,7 +29,7 @@ namespace AudioApp
             if (onBeat != nullptr) {
                 onBeat(diff);
             }
-            flash( 0.75f * (float)diff);
+            flash(0.75f * (float)diff);
         }
     }
 

--- a/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.cpp
@@ -6,7 +6,7 @@ namespace AudioApp
     const int multiplier = 4;
     static const int fadeIncrements = 8;
 
-    TempoSynthesizerComponent::TempoSynthesizerComponent(Logger& l): logger(l) {
+    TempoSynthesizerComponent::TempoSynthesizerComponent() {
         label.setColour (juce::Label::textColourId, colour);
         label.setJustificationType(juce::Justification::centred);
         addAndMakeVisible(label);

--- a/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
+++ b/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
@@ -4,22 +4,25 @@
 #include "CommonHeader.h"
 #include "../Libs/BTrack/BTrack.h"
 #include "Repeat.h"
+#include "LogOutputComponent.h"
 
 namespace AudioApp
 {
-    class TempoSynthesizerComponent : public juce::Component, juce::Timer
-    {
+    class TempoSynthesizerComponent : public juce::Component, juce::HighResolutionTimer, juce::Timer {
     public:
-        TempoSynthesizerComponent();
+        explicit TempoSynthesizerComponent(Logger& logger);
 
         void paint(Graphics& g) override;
         void resized() override;
         void timerCallback() override;
+        void hiResTimerCallback() override;
 
         void beat(long long period);
-
     private:
-        uint8_t currentBeat = 0;
+        Logger& logger;
+
+        // max uint8 value so that next beat makes it start on 0
+        uint8_t currentBeat = 255;
         juce::int64 lastTime = juce::Time::currentTimeMillis();
         double diffEwma = 0;
 
@@ -29,9 +32,17 @@ namespace AudioApp
         std::atomic<bool> dirty;
 
         void flash(float duration);
-        void updateLabel(uint8_t beat);
+        void updateBeat(uint8_t beat);
         void updateLabelColour(juce::Colour newColour);
 
         static double ewma(double current, double nextValue, double alpha);
+
+        struct scheduledBeat {
+            __int64_t millis;
+            uint8_t beat;
+        };
+
+        // deffo put locking on here if we're using high res scheduler with access from everywhere
+        std::list<scheduledBeat> scheduledBeats;
     };
 }

--- a/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
+++ b/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
@@ -10,7 +10,7 @@ namespace AudioApp
 {
     class TempoSynthesizerComponent : public juce::Component, juce::HighResolutionTimer, juce::Timer {
     public:
-        explicit TempoSynthesizerComponent(Logger& logger);
+        TempoSynthesizerComponent();
 
         void paint(Graphics& g) override;
         void resized() override;
@@ -19,8 +19,6 @@ namespace AudioApp
 
         void beat(long long period);
     private:
-        Logger& logger;
-
         // max uint8 value so that next beat makes it start on 0
         uint8_t currentBeat = 255;
         juce::int64 lastTime = juce::Time::currentTimeMillis();


### PR DESCRIPTION
Previously a less accurate Timer was used, rather than a HighResolutionTimer.

This change uses the HighResolutionTimer for the synthesized beats
and the regular Timer for the GUI update of the
TempoSynthesizerComponent.