### PR TITLE
⚡use sub millisecond measurements

### DIFF
--- a/Apps/AudioAppTemplate/Source/MainComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/MainComponent.cpp
@@ -11,7 +11,7 @@ namespace AudioApp
         addAndMakeVisible(audioSource);
         addAndMakeVisible(oscComponent);
 
-        tempoAnalyser.onBeat = [this](long long period) {
+        tempoAnalyser.onBeat = [this](double period) {
             oscComponent.sendBeatMessage();
             tempoSynthesizer.beat(period);
         };

--- a/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.cpp
@@ -6,6 +6,7 @@ namespace AudioApp
 
     TempoAnalyserComponent::TempoAnalyserComponent() {
         startTimerHz(60);
+        lastTime = juce::Time::getMillisecondCounterHiRes();
     }
 
     void TempoAnalyserComponent::paint(Graphics& g) {
@@ -23,7 +24,7 @@ namespace AudioApp
     void TempoAnalyserComponent::processAudioFrame (double* frame) {
         btrack.processAudioFrame(frame);
         if (btrack.beatDueInCurrentFrame()) {
-            auto current = juce::Time::currentTimeMillis();
+            auto current = juce::Time::getMillisecondCounterHiRes();
             auto diff = current - lastTime;
             lastTime = current;
             if (onBeat != nullptr) {

--- a/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.h
+++ b/Apps/AudioAppTemplate/Source/TempoAnalyserComponent.h
@@ -21,7 +21,7 @@ namespace AudioApp
 
         // onBeat is run whenever a new beat is encountered by btrack and
         // receives the duration since last detected beat as a parameter.
-        std::function<void(long long)> onBeat;
+        std::function<void(double)> onBeat;
 
     private:
         void flash(float duration);
@@ -31,7 +31,8 @@ namespace AudioApp
         int btrackHopSize = 256;
         BTrack btrack {btrackHopSize, btrackFrameSize };
 
-        juce::int64 lastTime = juce::Time::currentTimeMillis();
+        // cannot initialise here as juce::Time::getMillisecondCounterHiRes() returns 0 at this point
+        double lastTime;
 
         void setColour(Colour newColour);
         Colour colour = juce::Colours::grey;

--- a/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.cpp
@@ -36,12 +36,12 @@ namespace AudioApp
     void TempoSynthesizerComponent::hiResTimerCallback() {
         while (!scheduledBeats.empty()) {
             auto soonest = scheduledBeats.front();
-            // We call currentTimeMillis() within this loop but are assuming that the loop
+            // We call getMillisecondCounterHiRes() within this loop but are assuming that the loop
             // is rarely going to be ran for more than one iteration so it's probably
             // better most of the time to not call it before the loop and store it.
             // Although, this should definitely be benchmarked rather than worked on this
             // assumption.
-            if (juce::Time::currentTimeMillis() < soonest.millis) {
+            if (juce::Time::getMillisecondCounterHiRes() < soonest.millis) {
                 break;
             }
             updateBeat(soonest.beat);
@@ -50,8 +50,8 @@ namespace AudioApp
     }
 
     // beat is called on the beat detected with period being the time between each call
-    void TempoSynthesizerComponent::beat(long long period) {
-        auto timeOfBeat = juce::Time::currentTimeMillis();
+    void TempoSynthesizerComponent::beat(double period) {
+        auto timeOfBeat = juce::Time::getMillisecondCounterHiRes();
 
         diffEwma = ewma(diffEwma, (double)period, 0.5);
 
@@ -61,7 +61,7 @@ namespace AudioApp
 
         for (uint8_t i = 1; i < multiplier; ++i) {
             scheduledBeats.push_back(scheduledBeat{
-                timeOfBeat + (int)((float) diffEwma / (float) multiplier * (float)i),
+                timeOfBeat + (diffEwma / (double) multiplier * (double)i),
                 i,
             });
         }

--- a/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
+++ b/Apps/AudioAppTemplate/Source/TempoSynthesizerComponent.h
@@ -17,11 +17,10 @@ namespace AudioApp
         void timerCallback() override;
         void hiResTimerCallback() override;
 
-        void beat(long long period);
+        void beat(double period);
     private:
         // max uint8 value so that next beat makes it start on 0
         uint8_t currentBeat = 255;
-        juce::int64 lastTime = juce::Time::currentTimeMillis();
         double diffEwma = 0;
 
         juce::Label label;
@@ -36,7 +35,7 @@ namespace AudioApp
         static double ewma(double current, double nextValue, double alpha);
 
         struct scheduledBeat {
-            __int64_t millis;
+            double millis;
             uint8_t beat;
         };
 


### PR DESCRIPTION
Should increase accuracy a little more when extrapolating out to
schedule phantom beats/ticks in the future.