### PR TITLE
🐛fix logger timestamps

### DIFF
--- a/Apps/AudioAppTemplate/Source/LogOutputComponent.cpp
+++ b/Apps/AudioAppTemplate/Source/LogOutputComponent.cpp
@@ -73,6 +73,7 @@ namespace AudioApp
             logMessages.pop_back();
         }
 
+        now = time(nullptr);
         localtime_s(&ltm,&now);
 
         std::ostringstream oss;


### PR DESCRIPTION
Previously the timestamp was the timestamp of the startup of the application for all logged lines.